### PR TITLE
re-generate graph on cluster change

### DIFF
--- a/raptiformica.json
+++ b/raptiformica.json
@@ -7,6 +7,16 @@
       "source": "https://github.com/vdloo/raptiformica-map",
       "bootstrap": "./deploy.sh"
     }
+  },
+  "platform": {
+    "hooks": {
+      "cluster_change": {
+        "update_node_database": {
+          "predicate": "ps aux | grep -q /usr/etc/[r]aptiformica_map/raptiformica_map/web.py",
+          "command": "sleep $[($RANDOM%10)]; PYTHONPATH=/usr/etc/raptiformica_map /usr/etc/raptiformica_map/venv/bin/python3 /usr/etc/raptiformica_map/scripts/send_graph.py"
+        }
+      }
+    }
   }
 }
 

--- a/raptiformica_map/web.py
+++ b/raptiformica_map/web.py
@@ -1,5 +1,6 @@
 from flask import Flask, render_template, request
 from raptiformica_map.graph_data import insert_graph_data
+from raptiformica_map.update_graph import generate_graph
 
 app = Flask(__name__)
 app.config.from_pyfile('settings.cfg')
@@ -33,6 +34,7 @@ def page_send_graph():
         data=request.form['data'],
         version=version
     )
+    generate_graph()  # re-generate the graph with the new data
     return 'Error: {}'.format(ret) if ret else 'OK'
 
 if __name__ == '__main__':

--- a/tests/unit/raptiformica_map/web/test_page_send_graph.py
+++ b/tests/unit/raptiformica_map/web/test_page_send_graph.py
@@ -18,6 +18,7 @@ class TestPageSendGraph(TestCase):
         )
         self.app = Mock()
         self.set_up_patch('raptiformica_map.web.app', self.app)
+        self.generate_graph = self.set_up_patch('raptiformica_map.web.generate_graph')
 
     def test_page_send_graph_inserts_graph_data(self):
         page_send_graph()
@@ -40,6 +41,11 @@ class TestPageSendGraph(TestCase):
             data=self.request.form['data'],
             version=1
         )
+
+    def test_page_send_graph_regenerates_graph(self):
+        page_send_graph()
+
+        self.generate_graph.assert_called_once_with()
 
     def test_page_send_graph_returns_OK_if_no_error(self):
         self.insert_graph_data.return_value = None


### PR DESCRIPTION
on cluster change consul event:
1. randomly wait a bit to prevent a thundering herd
2. upload peers to the local webservice
3. local webservices stores the data in the distributed kv store
4. re-generate the graph with the new data
