### PR TITLE
don't do atomic rename for resolv.conf

### DIFF
--- a/provisioning/main.yml
+++ b/provisioning/main.yml
@@ -80,6 +80,15 @@
       create: yes
 
   - name: set 127.0.0.1 as first nameserver in resolv.conf
+    # can't do atomic rename in Docker because /etc/resolv.conf is mounted
+    # and the inode will change if we do lineinfile or sed -i, see
+    # https://forums.docker.com/t/container-losing-volume-etc-hosts-when-file-is-edited/10038/3
+    shell: >
+      grep '127.0.0.1' /etc/resolv.conf ||
+      (sed '1s/^/nameserver 127.0.0.1\n/' /etc/resolv.conf >
+      /tmp/resolv.conf &&
+      cat /tmp/resolv.conf > /etc/resolv.conf)
+
     lineinfile: dest=/etc/resolv.conf
                 regexp='^nameserver 127.0.0.1'
                 insertbefore=BOF
@@ -94,7 +103,7 @@
                 regexp='^nameserver 127.0.0.1'
                 insertbefore=BOF
                 line='nameserver 127.0.0.1'
-    when: resolv_conf_head.exists == True
+    when: resolv_conf_head.stat.exists == True
 
   - name: Configure dnsmasq for consul
     lineinfile:


### PR DESCRIPTION
fixes:

```
failed: [127.0.0.1] => {"failed": true}
msg: Could not replace file: /root/.ansible/tmp/ansible-tmp-1476131061.02-171091518774625/source to /etc/resolv.conf: [Errno 16] Device or resource busy
```

can't do atomic renames on mounted files because the inode would change. That's why this lineinfile does not work in a Docker https://forums.docker.com/t/container-losing-volume-etc-hosts-when-file-is-edited/10038/3
