### PR TITLE
increase proxy headers hash bucket size

### DIFF
--- a/provisioning/templates/nginx.conf
+++ b/provisioning/templates/nginx.conf
@@ -3,6 +3,7 @@ server {
     location / {
         include proxy_params;
         proxy_pass http://raptiformica_map.service.consul:3000;
+        proxy_headers_hash_bucket_size 128;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
fixes:

```
nginx: [emerg] could not build the proxy_headers_hash, you should increase either proxy_headers_hash_max_size: 1024 or proxy_headers_hash_bucket_size: 64
nginx: configuration file /etc/nginx/nginx.conf test failed
```
