### PR TITLE
work around not being able to resolve the proxy

### DIFF
--- a/provisioning/templates/nginx.conf
+++ b/provisioning/templates/nginx.conf
@@ -2,7 +2,8 @@ server {
     listen 80 default;
     location / {
         include proxy_params;
-        proxy_pass http://raptiformica_map.service.consul:3000;
+        set $backend_upstream "http://raptiformica_map.service.consul:3000";
+        proxy_pass $backend_upstream;
         proxy_headers_hash_bucket_size 128;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
when the first two nodes boot and there is no consul consensus yet or when during the first run dnsmasq has not been initialized when nginx runs the config validation when starting, the validation will fail because the proxy domain can not be resolved to the cjdns ipv6 peers

```
nginx: [emerg] host not found in upstream "raptiformica_map.service.consul" in /etc/nginx/sites-enabled/default:6
nginx: configuration file /etc/nginx/nginx.conf test failed
```

This PR works around that by setting the proxy_pass url in a variable. That way it is not evaluated during load time and we can start nginx even though we can't resolve the proxy backend yet.

See https://www.jethrocarr.com/2013/11/02/nginx-reverse-proxies-and-dns-resolution/
