### PR TITLE
Revert "work around not being able to resolve the proxy"

### DIFF
--- a/provisioning/templates/nginx.conf
+++ b/provisioning/templates/nginx.conf
@@ -2,8 +2,7 @@ server {
     listen 80 default;
     location / {
         include proxy_params;
-        set $backend_upstream "http://raptiformica_map.service.consul:3000";
-        proxy_pass $backend_upstream;
+        proxy_pass http://raptiformica_map.service.consul:3000;
         proxy_headers_hash_bucket_size 128;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
Reverts vdloo/raptiformica-map#21

doesn't work if there is no DNS entry for said host when nginx starts. need to just run the playbooks every time there is a cluster change for now
