### PR TITLE
strip leading zeroes also strips first character

### DIFF
--- a/raptiformica_map/graph_plotter.py
+++ b/raptiformica_map/graph_plotter.py
@@ -60,6 +60,8 @@ def strip_leading_zeroes(ipv6_address):
     :param str ipv6_address: the ipv6 address to strip zeroes from
     :return str stripped_ipv6_address: The stripped ipv6 address
     """
+    if ipv6_address[0] == '0':
+        ipv6_address = ipv6_address[1:]
     return ipv6_address.replace(':0', ':')
 
 

--- a/tests/unit/raptiformica_map/graph_plotter/test_strip_leading_zeroes.py
+++ b/tests/unit/raptiformica_map/graph_plotter/test_strip_leading_zeroes.py
@@ -1,0 +1,25 @@
+from raptiformica_map.graph_plotter import strip_leading_zeroes
+from tests.testcase import TestCase
+
+
+class TestStripLeadingZeroes(TestCase):
+    def test_strip_leading_zeroes_returns_complete_string_if_no_zeroes(self):
+        no_leading_zeroes_ipv6 = 'fc14:7b25:b1d5:d9ea:be0f:7a48:4e91:52f9'
+
+        ret = strip_leading_zeroes(no_leading_zeroes_ipv6)
+
+        self.assertEquals(ret, no_leading_zeroes_ipv6)
+
+    def test_strip_leading_zeroes_returns_string_with_stripped_zeroes_after_colons(self):
+        leading_zeroes_after_colons_ipv6 = 'fc14:7b25:01d5:d9ea:0e0f:7a48:4e91:52f9'
+
+        ret = strip_leading_zeroes(leading_zeroes_after_colons_ipv6)
+
+        self.assertEquals(ret, 'fc14:7b25:1d5:d9ea:e0f:7a48:4e91:52f9')
+
+    def test_strip_leading_zeroes_returns_string_with_stripped_zeroes_from_beginning(self):
+        leading_zeroes_after_beginning_ipv6 = '0c14:7b25:b1d5:d9ea:be0f:7a48:4e91:52f9'
+
+        ret = strip_leading_zeroes(leading_zeroes_after_beginning_ipv6)
+
+        self.assertEquals(ret, 'c14:7b25:b1d5:d9ea:be0f:7a48:4e91:52f9')


### PR DESCRIPTION
could also be a 0, currently only :0 was matched so the first segment was excluded.

todo: find out if there are cases where not only the first character of a segment could be a leading zero but also the second or third (or fourth?).
