### PR TITLE
install python-sphinx on archlinux

### DIFF
--- a/provisioning/main.yml
+++ b/provisioning/main.yml
@@ -40,6 +40,7 @@
     - python-pip
     - python
     - python-virtualenv
+    - python-sphinx
     - libmysqlclient
     - graphviz
     - pkg-config


### PR DESCRIPTION
Need sphinx-doc to compile wslay. On Archlinux this is called `python-sphinx`.

See: https://github.com/tatsuhiro-t/wslay/issues/27

fixes:
```
configure: summary of build options:

    version:        1.0.1-DEV shared 0:1:0
    Host type:      x86_64-unknown-linux-gnu
    Install prefix: /usr/local
    C compiler:     gcc
    CFlags:         -g -O2
    Library types:  Shared=yes, Static=yes
    CUnit:          yes
    Nettle:         yes
    Build examples: yes

root@archlinux:/usr/etc/wslay# make
make  all-recursive
make[1]: Entering directory '/usr/etc/wslay'
Making all in lib
make[2]: Entering directory '/usr/etc/wslay/lib'
Making all in includes
make[3]: Entering directory '/usr/etc/wslay/lib/includes'
make[3]: Nothing to be done for 'all'.
make[3]: Leaving directory '/usr/etc/wslay/lib/includes'
make[3]: Entering directory '/usr/etc/wslay/lib'
/bin/sh ../libtool  --tag=CC   --mode=compile gcc -DHAVE_CONFIG_H -I. -I..  -DHAVE_CONFIG_H -I./includes -I./includes  -Wall -g -O2 -MT wslay_frame.lo -MD -MP -MF .deps/wslay_frame.Tpo -c -o wslay_frame.lo wslay_frame.c
libtool: compile:  gcc -DHAVE_CONFIG_H -I. -I.. -DHAVE_CONFIG_H -I./includes -I./includes -Wall -g -O2 -MT wslay_frame.lo -MD -MP -MF .deps/wslay_frame.Tpo -c wslay_frame.c  -fPIC -DPIC -o .libs/wslay_frame.o
libtool: compile:  gcc -DHAVE_CONFIG_H -I. -I.. -DHAVE_CONFIG_H -I./includes -I./includes -Wall -g -O2 -MT wslay_frame.lo -MD -MP -MF .deps/wslay_frame.Tpo -c wslay_frame.c -o wslay_frame.o >/dev/null 2>&1
mv -f .deps/wslay_frame.Tpo .deps/wslay_frame.Plo
/bin/sh ../libtool  --tag=CC   --mode=compile gcc -DHAVE_CONFIG_H -I. -I..  -DHAVE_CONFIG_H -I./includes -I./includes  -Wall -g -O2 -MT wslay_event.lo -MD -MP -MF .deps/wslay_event.Tpo -c -o wslay_event.lo wslay_event.c
libtool: compile:  gcc -DHAVE_CONFIG_H -I. -I.. -DHAVE_CONFIG_H -I./includes -I./includes -Wall -g -O2 -MT wslay_event.lo -MD -MP -MF .deps/wslay_event.Tpo -c wslay_event.c  -fPIC -DPIC -o .libs/wslay_event.o
libtool: compile:  gcc -DHAVE_CONFIG_H -I. -I.. -DHAVE_CONFIG_H -I./includes -I./includes -Wall -g -O2 -MT wslay_event.lo -MD -MP -MF .deps/wslay_event.Tpo -c wslay_event.c -o wslay_event.o >/dev/null 2>&1
mv -f .deps/wslay_event.Tpo .deps/wslay_event.Plo
/bin/sh ../libtool  --tag=CC   --mode=compile gcc -DHAVE_CONFIG_H -I. -I..  -DHAVE_CONFIG_H -I./includes -I./includes  -Wall -g -O2 -MT wslay_queue.lo -MD -MP -MF .deps/wslay_queue.Tpo -c -o wslay_queue.lo wslay_queue.c
libtool: compile:  gcc -DHAVE_CONFIG_H -I. -I.. -DHAVE_CONFIG_H -I./includes -I./includes -Wall -g -O2 -MT wslay_queue.lo -MD -MP -MF .deps/wslay_queue.Tpo -c wslay_queue.c  -fPIC -DPIC -o .libs/wslay_queue.o
libtool: compile:  gcc -DHAVE_CONFIG_H -I. -I.. -DHAVE_CONFIG_H -I./includes -I./includes -Wall -g -O2 -MT wslay_queue.lo -MD -MP -MF .deps/wslay_queue.Tpo -c wslay_queue.c -o wslay_queue.o >/dev/null 2>&1
mv -f .deps/wslay_queue.Tpo .deps/wslay_queue.Plo
/bin/sh ../libtool  --tag=CC   --mode=compile gcc -DHAVE_CONFIG_H -I. -I..  -DHAVE_CONFIG_H -I./includes -I./includes  -Wall -g -O2 -MT wslay_net.lo -MD -MP -MF .deps/wslay_net.Tpo -c -o wslay_net.lo wslay_net.c
libtool: compile:  gcc -DHAVE_CONFIG_H -I. -I.. -DHAVE_CONFIG_H -I./includes -I./includes -Wall -g -O2 -MT wslay_net.lo -MD -MP -MF .deps/wslay_net.Tpo -c wslay_net.c  -fPIC -DPIC -o .libs/wslay_net.o
libtool: compile:  gcc -DHAVE_CONFIG_H -I. -I.. -DHAVE_CONFIG_H -I./includes -I./includes -Wall -g -O2 -MT wslay_net.lo -MD -MP -MF .deps/wslay_net.Tpo -c wslay_net.c -o wslay_net.o >/dev/null 2>&1
mv -f .deps/wslay_net.Tpo .deps/wslay_net.Plo
/bin/sh ../libtool  --tag=CC   --mode=link gcc -Wall -g -O2 -no-undefined -version-info 0:1:0  -o libwslay.la -rpath /usr/local/lib  wslay_frame.lo wslay_event.lo wslay_queue.lo wslay_net.lo
libtool: link: rm -fr  .libs/libwslay.a .libs/libwslay.la .libs/libwslay.lai .libs/libwslay.so .libs/libwslay.so.0 .libs/libwslay.so.0.0.1
libtool: link: gcc -shared  -fPIC -DPIC  .libs/wslay_frame.o .libs/wslay_event.o .libs/wslay_queue.o .libs/wslay_net.o    -g -O2   -Wl,-soname -Wl,libwslay.so.0 -o .libs/libwslay.so.0.0.1
libtool: link: (cd ".libs" && rm -f "libwslay.so.0" && ln -s "libwslay.so.0.0.1" "libwslay.so.0")
libtool: link: (cd ".libs" && rm -f "libwslay.so" && ln -s "libwslay.so.0.0.1" "libwslay.so")
libtool: link: ar cru .libs/libwslay.a  wslay_frame.o wslay_event.o wslay_queue.o wslay_net.o
ar: `u' modifier ignored since `D' is the default (see `U')
libtool: link: ranlib .libs/libwslay.a
libtool: link: ( cd ".libs" && rm -f "libwslay.la" && ln -s "../libwslay.la" "libwslay.la" )
make[3]: Leaving directory '/usr/etc/wslay/lib'
make[2]: Leaving directory '/usr/etc/wslay/lib'
Making all in tests
make[2]: Entering directory '/usr/etc/wslay/tests'
make[2]: Nothing to be done for 'all'.
make[2]: Leaving directory '/usr/etc/wslay/tests'
Making all in examples
make[2]: Entering directory '/usr/etc/wslay/examples'
gcc -DHAVE_CONFIG_H -I. -I..  -Wall -I../lib/includes -I../lib/includes  -DHAVE_CONFIG_H   -g -O2 -MT fork-echoserv.o -MD -MP -MF .deps/fork-echoserv.Tpo -c -o fork-echoserv.o fork-echoserv.c
mv -f .deps/fork-echoserv.Tpo .deps/fork-echoserv.Po
/bin/sh ../libtool  --tag=CC   --mode=link gcc  -g -O2 -lnettle  -o fork-echoserv fork-echoserv.o ../lib/libwslay.la
libtool: link: gcc -g -O2 -o .libs/fork-echoserv fork-echoserv.o  -lnettle ../lib/.libs/libwslay.so -Wl,-rpath -Wl,/usr/local/lib
g++ -DHAVE_CONFIG_H -I. -I..  -Wall -I../lib/includes -I../lib/includes  -DHAVE_CONFIG_H   -g -O2 -MT echoserv.o -MD -MP -MF .deps/echoserv.Tpo -c -o echoserv.o echoserv.cc
mv -f .deps/echoserv.Tpo .deps/echoserv.Po
/bin/sh ../libtool  --tag=CXX   --mode=link g++  -g -O2 -lnettle  -o echoserv echoserv.o ../lib/libwslay.la
libtool: link: g++ -g -O2 -o .libs/echoserv echoserv.o  -lnettle ../lib/.libs/libwslay.so -Wl,-rpath -Wl,/usr/local/lib
g++ -DHAVE_CONFIG_H -I. -I..  -Wall -I../lib/includes -I../lib/includes  -DHAVE_CONFIG_H   -g -O2 -MT testclient.o -MD -MP -MF .deps/testclient.Tpo -c -o testclient.o testclient.cc
mv -f .deps/testclient.Tpo .deps/testclient.Po
/bin/sh ../libtool  --tag=CXX   --mode=link g++  -g -O2 -lnettle  -o testclient testclient.o ../lib/libwslay.la
libtool: link: g++ -g -O2 -o .libs/testclient testclient.o  -lnettle ../lib/.libs/libwslay.so -Wl,-rpath -Wl,/usr/local/lib
make[2]: Leaving directory '/usr/etc/wslay/examples'
Making all in doc
make[2]: Entering directory '/usr/etc/wslay/doc'
make[2]: *** No rule to make target 'man/wslay_event_context_server_init.3', needed by 'all-am'.  Stop.
make[2]: Leaving directory '/usr/etc/wslay/doc'
make[1]: *** [Makefile:442: all-recursive] Error 1
make[1]: Leaving directory '/usr/etc/wslay'
make: *** [Makefile:370: all] Error 2
```