### PR TITLE
change consul service name

### DIFF
--- a/provisioning/templates/consul_service_configuration.json
+++ b/provisioning/templates/consul_service_configuration.json
@@ -1,7 +1,7 @@
 {
   "service": 
   {
-    "name": "raptiformica_map", 
+    "name": "raptiformicamap",
     "port": 3000
   }
 }

--- a/provisioning/templates/h2o.conf
+++ b/provisioning/templates/h2o.conf
@@ -5,4 +5,4 @@ hosts:
     paths:
       "/":
         # reverse proxy without caching DNS
-        proxy.reverse.url: http://raptiformica_map.service.consul:3000/
+        proxy.reverse.url: http://raptiformicamap.service.consul:3000/


### PR DESCRIPTION
from raptiformica_map to raptiformicamap

fixes:
```
2016/12/03 15:14:25 [WARN] Service name "raptiformica_map" will not be discoverable via DNS due to invalid characters. Valid characters include all alpha-numerics and dashes.
```