### PR TITLE
remove cunit from archlinux requirements

### DIFF
--- a/provisioning/main.yml
+++ b/provisioning/main.yml
@@ -50,7 +50,6 @@
     - cmake
     - zlib
     - ruby
-    - cunit
     - nettle
     - libuv
     - libyaml


### PR DESCRIPTION
don't need it to build h2o