### PR TITLE
service definition has check

### DIFF
--- a/provisioning/templates/consul_service_configuration.json
+++ b/provisioning/templates/consul_service_configuration.json
@@ -2,6 +2,10 @@
   "service": 
   {
     "name": "raptiformicamap",
-    "port": 3000
+    "port": 3000,
+    "check":  {
+      "script": "GET http://localhost:3000 >/dev/null 2>&1",
+      "interval": "10s"
+    }
   }
 }


### PR DESCRIPTION
so consul does not loadbalance to machines that couldn't compile h2o or can't run the webserver for some reason.