### PR TITLE
do not install libmysqlclient on archlinux

### DIFF
--- a/provisioning/main.yml
+++ b/provisioning/main.yml
@@ -37,7 +37,6 @@
     - python
     - python-virtualenv
     - python-sphinx
-    - libmysqlclient
     - graphviz
     - pkg-config
     - dnsmasq


### PR DESCRIPTION
it is from the AUR, don't really need it anyway in this env.