### PR TITLE
pin ansible to 2.2.3.0

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -5,7 +5,7 @@ set -e
 if type apt-get > /dev/null 2>&1; then
     apt-get install python3 python-apt python3-dev libffi-dev libssl-dev -y
     apt-get purge ansible -y || /bin/true
-    pip install ansible
+    pip install ansible==2.2.3.0
     ansible-playbook provisioning/main.yml --connection=local --connection=local -i '127.0.0.1,' -vvv
 fi;
 


### PR DESCRIPTION
newer versions don't work nice with python 3.4. closes https://github.com/vdloo/raptiformica-map/issues/86